### PR TITLE
[semver:minor] Added ability to specify version in `git-clone-perk` command by using an env var like so: `<PERK_NAME>_<BRANCH_NAME>`.

### DIFF
--- a/src/commands/git-clone-perk.yml
+++ b/src/commands/git-clone-perk.yml
@@ -15,8 +15,20 @@ steps:
   - run:
       name: 'Git Clone Perk: <<parameters.perk>>'
       command: |
-        git clone git@github.com:gravitywiz/<<parameters.perk>>.git /plugins/<<parameters.perk>>
+        # Convert perk name to uppercase and append _BRANCH to construct the environment variable name
+        PERK_BRANCH_VAR=$(echo "<<parameters.perk>>_BRANCH" | tr '[:lower:]' '[:upper:]')
+
+        # Use parameter expansion to get the value of the environment variable
+        PERK_BRANCH=${!PERK_BRANCH_VAR}
+
+        # Clone the repositories by don't checkout any files yet.
+        git clone --no-checkout git@github.com:gravitywiz/<<parameters.perk>>.git /plugins/<<parameters.perk>>
+
         cd /plugins/<<parameters.perk>>
+
+        # Checkout the branch defined by PERK_BRANCH or default to the current branch. This also checks out files.
+        git checkout ${PERK_BRANCH:-$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')}
+
         git rev-parse HEAD > /tmp/<<parameters.perk>>-commit.txt
   - restore_cache:
       condition:


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Added the ability to specify a version of a perk to checkout and build when running Cypress tests.

## Motivation:

Sometimes mulitple plugins rely on changes in one another, like in the case of GPGS and Gravityperks or GCN and Gravityperks.

This allows one to run tests in GPGS, GCN, or other perks that need to run against a non-merged, non-released branch of Gravityperks.


 **Closes Issues:**
-  ISSUE URL

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
