### PR TITLE
[semver:minor] Added ability to specify `node-version` parameter.

### DIFF
--- a/src/commands/ensure-node-version.yml
+++ b/src/commands/ensure-node-version.yml
@@ -1,0 +1,27 @@
+description: >
+  Install fnm and switch Node versions if specified version is not blank and differs from the version in the container.
+
+parameters:
+  version:
+    type: string
+    description: >
+      The version of Node.js to use.
+    default: ""
+
+steps:
+  - run:
+      name: Check current version of node
+      command: node -v
+  - run:
+      name: "Install fnm (Fast Node Manager) and specified Node.js version"
+      command: |
+        if [ -n "<< parameters.version >>" ]; then
+          CURRENT_NODE_VERSION=$(node -v)
+          if [ "$CURRENT_NODE_VERSION" != "v<< parameters.version >>" ]; then
+            curl -fsSL https://fnm.vercel.app/install | bash
+            export PATH=$HOME/.fnm:$PATH
+            eval "$(fnm env)"
+            fnm install << parameters.version >>
+            fnm use << parameters.version >>
+          fi
+        fi

--- a/src/jobs/cypress.yml
+++ b/src/jobs/cypress.yml
@@ -12,11 +12,16 @@ parameters:
       Deprecated
     enum: [ "9", "10", "latest" ]
     default: "latest"
+  node-version:
+    type: string
+    description: >
+      The version of Node.js to use. The container has v16.16.0 pre-installed.
+    default: ""
   gf-version:
     type: enum
     description: >
       The release channel of Gravity Forms to use for the tests.
-    enum: [ "hotfix", "beta", "auto-update", "2.4" ]
+    enum: [ "hotfix", "beta", "auto-update" ]
   perk:
     type: string
     description: >
@@ -49,6 +54,8 @@ environment:
 
 steps:
   - checkout
+  - ensure-node-version:
+      version: << parameters.node-version >>
   - install-yarn-deps
   - git-clone-gravityforms:
       version: << parameters.gf-version >>


### PR DESCRIPTION
Added ability to specify `node-version` parameter.

The container currently uses Node 16 which prevents us from being able to update some packages in our plugins. This will allow us to start upgrading deps more aggressively.