### PR TITLE
[semver:major] Updated to clone and use `spellbook` instead of `gravityperks`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 3
 
 orbs:
   # Replace this with your own!

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
-version: 2.1
+version: 3.0
 
 description: >
-  Orb for performing actions on Gravity Perks including running tests.
+  Orb for performing actions on Gravity Wiz Plugins including running tests.
 
 display:
   home_url: "https://www.notion.so/gravitywiz/Developer-Docs-a589ffb06f7c4d73b6da3defe1c86f78"

--- a/src/examples/job-cypress.yml
+++ b/src/examples/job-cypress.yml
@@ -2,10 +2,10 @@ description: >
   Usage of the Cypress job.
 
 usage:
-  version: 2.1
+  version: 3.0
 
   orbs:
-    perk: gravitywiz/perk@1
+    perk: gravitywiz/perk@3
 
   workflows:
     test:

--- a/src/jobs/cypress.yml
+++ b/src/jobs/cypress.yml
@@ -36,10 +36,10 @@ parameters:
     description: >
       Whether or not to run yarn build.
     default: true
-  clone-gravityperks:
+  clone-spellbook:
     type: boolean
     description: >
-      Whether Gravity Perks itself should be cloned.
+      Whether Spellbook itself should be cloned.
     default: true
   after-deps:
     description: "Steps that will be executed after dependencies are installed, but before tests are run"
@@ -61,10 +61,10 @@ steps:
       version: << parameters.gf-version >>
   - when:
       condition:
-        equal: [ true, << parameters.clone-gravityperks >> ]
+        equal: [ true, << parameters.clone-spellbook >> ]
       steps:
         - git-clone-perk:
-            perk: gravityperks
+            perk: spellbook 
   - when:
       condition:
         equal: [ true, << parameters.run-yarn-build >> ]


### PR DESCRIPTION
**SEMVER Update Type:**
- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

Updates the orb to install Spellbook instead of Gravity Perks.


## Motivation:

Because Spellbook rules :crown:

 **Closes Issues:**
-  ISSUE URL

## Checklist:

- [ ] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

